### PR TITLE
More secure access code handling

### DIFF
--- a/crtool/fixtures/crtool_initial_data.json
+++ b/crtool/fixtures/crtool_initial_data.json
@@ -3,11 +3,11 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "02d19cc1314747ef8aacb3",
     "fields": {
-        "pass_code": "",
+        "pass_code": "02d19cc1",
         "data": {
             "id": "02d19cc1314747ef8aacb3",
             "START": "Quality",
-            "pass_code": "",
+            "pass_code": "02d19cc1",
             "gradeRange": "High school",
             "last_updated": "2020-08-06T00:59:22.576547+00:00",
             "quality_status": "in progress",
@@ -27,11 +27,11 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "1da8305db6774e46970ec3",
     "fields": {
-        "pass_code": "",
+        "pass_code": "1da8305d",
         "data": {
             "id": "1da8305db6774e46970ec3",
             "START": "Utility",
-            "pass_code": "",
+            "pass_code": "1da8305d",
             "gradeRange": "High school",
             "last_updated": "2020-07-23T00:49:15.837096+00:00",
             "utility_status": "in progress",
@@ -48,10 +48,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "242449c9251243c1b512d2",
     "fields": {
-        "pass_code": null,
+        "pass_code": "242449c9",
         "data": {
             "id": "242449c9251243c1b512d2",
-            "pass_code": null,
+            "pass_code": "242449c9",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 04:52:56.858970+00:00",
             "curriculumTitle": "test",
@@ -64,10 +64,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "6893d3af8eb54e74a27882",
     "fields": {
-        "pass_code": "",
+        "pass_code": "6893d3af",
         "data": {
             "id": "6893d3af8eb54e74a27882",
-            "pass_code": "",
+            "pass_code": "6893d3af",
             "gradeRange": "Elementary school",
             "last_updated": "2020-07-14 03:56:52.402982+00:00",
             "curriculumTitle": "test",
@@ -81,11 +81,11 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "76fa6efe1cdd44989ce6a3",
     "fields": {
-        "pass_code": "",
+        "pass_code": "76fa6efe",
         "data": {
             "id": "76fa6efe1cdd44989ce6a3",
             "START": "Quality",
-            "pass_code": "",
+            "pass_code": "76fa6efe",
             "gradeRange": "Elementary school",
             "last_updated": "2020-08-06T23:43:42.257127+00:00",
             "content_status": "in progress",
@@ -106,11 +106,11 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "99a3f2491f3546dd85c874",
     "fields": {
-        "pass_code": "",
+        "pass_code": "99a3f249",
         "data": {
             "id": "99a3f2491f3546dd85c874",
             "START": "Quality",
-            "pass_code": "",
+            "pass_code": "99a3f249",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-23T00:49:42.626091+00:00",
             "content_status": "complete",
@@ -137,10 +137,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "9e88876a7530462497d311",
     "fields": {
-        "pass_code": "",
+        "pass_code": "9e88876a",
         "data": {
             "id": "9e88876a7530462497d311",
-            "pass_code": "",
+            "pass_code": "9e88876a",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 19:24:34.353929+00:00",
             "curriculumTitle": "test",
@@ -153,10 +153,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "ab4070b203c54eae9618a8",
     "fields": {
-        "pass_code": null,
+        "pass_code": "ab4070b2",
         "data": {
             "id": "ab4070b203c54eae9618a8",
-            "pass_code": null,
+            "pass_code": "ab4070b2",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 19:14:45.018366+00:00",
             "curriculumTitle": "test",
@@ -169,10 +169,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "bef8b726860c4d4e96097e",
     "fields": {
-        "pass_code": "",
+        "pass_code": "bef8b726",
         "data": {
             "id": "bef8b726860c4d4e96097e",
-            "pass_code": "",
+            "pass_code": "bef8b726",
             "gradeRange": "High school",
             "last_updated": "2020-08-06T22:17:11.977685+00:00",
             "curriculumTitle": "Yet Another Review",
@@ -185,11 +185,11 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "c193380d5e3c4d198daa81",
     "fields": {
-        "pass_code": "",
+        "pass_code": "c193380d",
         "data": {
             "id": "c193380d5e3c4d198daa81",
             "START": "Content",
-            "pass_code": "",
+            "pass_code": "c193380d",
             "gradeRange": "Elementary school",
             "last_updated": "2020-07-16T17:48:00.245613+00:00",
             "content_status": "in progress",
@@ -208,10 +208,10 @@
     "model": "crtool.curriculumreviewsession",
     "pk": "fc0751322722457c8ba3fc",
     "fields": {
-        "pass_code": "",
+        "pass_code": "fc075132",
         "data": {
             "id": "fc0751322722457c8ba3fc",
-            "pass_code": "",
+            "pass_code": "fc075132",
             "gradeRange": "Middle school",
             "last_updated": "2020-07-12 19:32:55.165041+00:00",
             "curriculumTitle": "test",

--- a/crtool/jinja2/crtool/crt-base.html
+++ b/crtool/jinja2/crtool/crt-base.html
@@ -33,6 +33,10 @@
 {# BODY items #}
 
 {% block header %}
+    {{ csrf_input }}
+    <script>
+      window.csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    </script>
     <header class="o-header u-hide-on-print" role="banner">
         <div class="m-global-eyebrow m-global-eyebrow__horizontal">
             <div class="wrapper wrapper__match-content">

--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -235,12 +235,12 @@
         <div class="o-tabs_tab o-tabs_tab__continue-review">
             <h2>Continue a review</h2>
             <p>Enter your access code to return to a review in progress.</p>
-            <form id="form__continue-review" class="o-form" method="GET" action="../tool">
+            <form id="form__continue-review" class="o-form" method="POST" action="../continue-review/">
                 <div class="o-form_group">
                     <div class="m-form-field m-form-field__select">
                     <label class="a-label a-label__heading" for="token--continue">Access code</label>
                     <div class="a-select">
-                        <select id="token--continue" name="token" value="">
+                        <select id="token--continue" name="pass_code" value="">
                             <option value="">Enter your access code</option>
                         </select>
                         </div>
@@ -266,7 +266,7 @@
                     </div>
                 </div>
                 <div class="m-btn-group m-btn-group__wide">
-                    <button id="continue-review" class="a-btn button-push-analytics" type="submit" formaction="../tool">
+                    <button id="continue-review" class="a-btn button-push-analytics" type="submit">
                             Continue review
                     </button>
                 </div>

--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -34,6 +34,10 @@
 {# BODY items #}
 
 {% block header %}
+    {{ csrf_input }}
+    <script>
+      window.csrftoken = document.querySelector('[name=csrfmiddlewaretoken]').value;
+    </script>
     <header class="o-header" role="banner">
         <div class="m-global-eyebrow m-global-eyebrow__horizontal">
             <div class="wrapper wrapper__match-content">
@@ -236,6 +240,7 @@
             <h2>Continue a review</h2>
             <p>Enter your access code to return to a review in progress.</p>
             <form id="form__continue-review" class="o-form" method="POST" action="../continue-review/">
+                {{ csrf_input }}
                 <div class="o-form_group">
                     <div class="m-form-field m-form-field__select">
                     <label class="a-label a-label__heading" for="token--continue">Access code</label>

--- a/crtool/jinja2/crtool/crt-start.html
+++ b/crtool/jinja2/crtool/crt-start.html
@@ -240,7 +240,7 @@
                     <div class="m-form-field m-form-field__select">
                     <label class="a-label a-label__heading" for="token--continue">Access code</label>
                     <div class="a-select">
-                        <select id="token--continue" name="pass_code" value="">
+                        <select id="token--continue" name="pass_code">
                             <option value="">Enter your access code</option>
                         </select>
                         </div>

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -301,6 +301,7 @@ function beginReviewButtonClick( event ) {
   };
   const requestUrl = '../create-review/';
   xhttp.open( 'POST', requestUrl );
+  xhttp.setRequestHeader('X-CSRFToken', window.csrftoken);
   xhttp.send(
     JSON.stringify( {
       'tdp-crt_title': curriculumTitle,

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -179,14 +179,14 @@ function getAvailableReviews() {
     if ( key.search( /^crtool\./i ) !== -1 ) {
       token = key.replace( 'crtool.', '' );
       const review = getReviewFromLocalStorage( token );
-      const pass_code = review.pass_code;
-      const label = review.curriculumTitle
-        ? pass_code + ' (' + review.curriculumTitle + ')'
-        : pass_code;
-      reviews.push({
+      const passCode = review.pass_code;
+      const label = review.curriculumTitle ?
+        passCode + ' (' + review.curriculumTitle + ')' :
+        passCode;
+      reviews.push( {
         review: review,
-        label: label,
-      });
+        label: label
+      } );
     }
   }
   return reviews;
@@ -201,11 +201,11 @@ function setUpTokenDropdown() {
 
   let selectedPassCode = '';
   for ( const obj of objs ) {
-    if ( currentReview && currentReview.id === obj.review.id )  {
+    if ( currentReview && currentReview.id === obj.review.id ) {
       selectedPassCode = obj.review.pass_code;
     }
     // We don't bother declaring options pre-selected. See below.
-    const opt = new Option(obj.label, obj.review.pass_code);
+    const opt = new Option( obj.label, obj.review.pass_code );
     $( '#token--continue' ).append( opt );
   }
   $( '#token--continue' ).select2( {
@@ -214,11 +214,14 @@ function setUpTokenDropdown() {
     multiple: false
   } );
 
-  // This delayed setting of value fixes two Select2 bugs:
-  // 1. Even if you give it Options that are pre-selected, the "tags" feature
-  //    will set selectedIndex to -1, so val() will still be null.
-  // 2. If you set via val() immediately, it just won't work. Hence, this
-  //    hacky delay is necessary.
+  /**
+   * This delayed setting of value fixes two Select2 bugs:
+   *
+   * 1. Even if you give it Options that are pre-selected, the "tags" feature
+   *    will set selectedIndex to -1, so val() will still be null.
+   * 2. If you set via val() immediately, it just won't work. Hence, this
+   *    hacky delay is necessary.
+   */
   setTimeout( () => {
     if ( selectedPassCode ) {
       $( '#token--continue' ).val( selectedPassCode );

--- a/crtool/js/startPage.js
+++ b/crtool/js/startPage.js
@@ -167,12 +167,12 @@ function saveWorkOutsideClickListener( event ) {
 }
 
 /**
- * Get available tokens from localStorage.
+ * Get available reviews from localStorage.
  *
- * @returns {Array} - List of available tokens
+ * @returns {Array} - List of available reviews
  */
-function getAvailableTokens() {
-  const tokens = {};
+function getAvailableReviews() {
+  const reviews = [];
   let key;
   let token;
   for ( let i = 0; i < localStorage.length; i++ ) {
@@ -180,26 +180,32 @@ function getAvailableTokens() {
     if ( key.search( /^crtool\./i ) !== -1 ) {
       token = key.replace( 'crtool.', '' );
       const review = getReviewFromLocalStorage( token );
-      const reviewTitle = review.curriculumTitle ? token + ' (' + review.curriculumTitle + ')' : token;
-      tokens[token] = reviewTitle;
+      const pass_code = review.pass_code;
+      const label = review.curriculumTitle
+        ? pass_code + ' (' + review.curriculumTitle + ')'
+        : pass_code;
+      reviews.push({
+        review: review,
+        label: label,
+      });
     }
   }
-  return tokens;
+  return reviews;
 }
 
 /**
  *
  */
 function setUpTokenDropdown() {
-  const tokens = getAvailableTokens();
-  const review = getCurrentReview();
+  const objs = getAvailableReviews();
+  const currentReview = getCurrentReview();
 
-  for ( const token in tokens ) {
+  for ( const obj of objs ) {
     let markup;
-    if ( review && review.id === token ) {
-      markup = '<option value="' + token + '" selected="selected">' + tokens[token] + '</option>';
+    if ( currentReview && currentReview.id === obj.review.id ) {
+      markup = '<option value="' + obj.review.pass_code + '" selected="selected">' + obj.label + '</option>';
     } else {
-      markup = '<option value="' + token + '">' + tokens[token] + '</option>';
+      markup = '<option value="' + obj.review.pass_code + '">' + obj.label + '</option>';
     }
     $( '#token--continue' ).append( markup );
   }
@@ -279,7 +285,7 @@ function beginReviewButtonClick( event ) {
       const review = JSON.parse( this.responseText );
       localStorage.setItem( 'curriculumReviewId', review.id );
       localStorage.setItem( 'crtool.' + review.id, JSON.stringify( review ) );
-      window.location.href = '../tool?token=' + review.id;
+      location.href = '../tool/?token=' + review.id;
     }
   };
   const requestUrl = '../create-review/';

--- a/crtool/models.py
+++ b/crtool/models.py
@@ -14,19 +14,21 @@ class CurriculumReviewSession(models.Model):
     data = JSONField()
     last_updated = models.DateTimeField('Updated', default=timezone.now)
 
-    # To gain access to a session ID, the password must be given and we check it
-    # with a long delay to avoid brute forcing. This is nowhere near as secure
-    # as traditional password hash but we don't have usernames, so we can't look
-    # up a hash.
-    def pass_code_generator(size=8, chars=string.ascii_letters + string.digits):
+    # To gain access to a session ID, the password must be given and we
+    # check it with a long delay to avoid brute forcing. This is nowhere
+    # near as secure as traditional password hash but we don't have
+    # usernames, so we can't look up a hash.
+    def pc_generator(size=8, chars=string.ascii_letters + string.digits):
         temp_id = ''.join(random.choice(chars) for _ in range(size))
-        while CurriculumReviewSession.objects.filter(pass_code=temp_id).exists():
+        objs = CurriculumReviewSession.objects
+        while objs.filter(pass_code=temp_id).exists():
             temp_id = ''.join(random.choice(chars) for _ in range(size))
         return temp_id
 
     def id_generator(size=22, chars=string.ascii_letters + string.digits):
         temp_id = ''.join(random.choice(chars) for _ in range(size))
-        while CurriculumReviewSession.objects.filter(id=temp_id).exists():
+        objs = CurriculumReviewSession.objects
+        while objs.filter(id=temp_id).exists():
             temp_id = ''.join(random.choice(chars) for _ in range(size))
         return temp_id
 

--- a/crtool/models.py
+++ b/crtool/models.py
@@ -14,6 +14,16 @@ class CurriculumReviewSession(models.Model):
     data = JSONField()
     last_updated = models.DateTimeField('Updated', default=timezone.now)
 
+    # To gain access to a session ID, the password must be given and we check it
+    # with a long delay to avoid brute forcing. This is nowhere near as secure
+    # as traditional password hash but we don't have usernames, so we can't look
+    # up a hash.
+    def pass_code_generator(size=8, chars=string.ascii_letters + string.digits):
+        temp_id = ''.join(random.choice(chars) for _ in range(size))
+        while CurriculumReviewSession.objects.filter(pass_code=temp_id).exists():
+            temp_id = ''.join(random.choice(chars) for _ in range(size))
+        return temp_id
+
     def id_generator(size=22, chars=string.ascii_letters + string.digits):
         temp_id = ''.join(random.choice(chars) for _ in range(size))
         while CurriculumReviewSession.objects.filter(id=temp_id).exists():

--- a/crtool/tests/test_views.py
+++ b/crtool/tests/test_views.py
@@ -1,14 +1,15 @@
 # from django.test import TestCase
 import json
 
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+
 from crtool.views import (
     continue_review,
     create_review,
     get_review,
     update_review,
 )
-from django.test import RequestFactory, TestCase
-from django.urls import reverse
 
 
 class CreateReviewTest(TestCase):

--- a/crtool/urls.py
+++ b/crtool/urls.py
@@ -20,7 +20,7 @@ urlpatterns = [
     ),
     re_path(
         r'^get-review/$',
-        views.get_review_by_id,
+        views.get_review,
         name='get_review'
     ),
     re_path(

--- a/crtool/urls.py
+++ b/crtool/urls.py
@@ -20,8 +20,13 @@ urlpatterns = [
     ),
     re_path(
         r'^get-review/$',
-        views.get_review,
+        views.get_review_by_id,
         name='get_review'
+    ),
+    re_path(
+        r'^continue-review/$',
+        views.continue_review,
+        name='continue_review'
     ),
     re_path(
         r'^update-review/$',

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -1,8 +1,9 @@
 import json
+import time
 from datetime import datetime
 
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
 from django.utils import timezone
 from django.views.decorators.csrf import csrf_exempt
 
@@ -17,15 +18,18 @@ def create_review(request):
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
         grade_range = fd['tdp-crt_grade'] if 'tdp-crt_grade' in fd else ''
-        passcode = fd['tdp-crt_pass_code'] if 'tdp-crt_pass_code' in fd else ''
+        pass_code = CurriculumReviewSession.pass_code_generator()
         review_id = CurriculumReviewSession.id_generator()
         last_updated = timezone.now()
 
         if not title or not grade_range:
             return HttpResponse(status=400)
         data = {
+            # Session ID, >128-bit entropy
             'id': str(review_id),
-            'pass_code': passcode,
+            # Password, lower entropy but we at least force users using this to
+            # wait a second to avoid brute-forcing.
+            'pass_code': str(pass_code),
             'last_updated': str(datetime.isoformat(last_updated)),
             'curriculumTitle': title,
             'publicationDate': pub_date,
@@ -34,7 +38,7 @@ def create_review(request):
 
         review = CurriculumReviewSession.objects.create(
             id=review_id,
-            pass_code=passcode,
+            pass_code=pass_code,
             last_updated=last_updated,
             data=data
         )
@@ -43,13 +47,13 @@ def create_review(request):
             return JsonResponse(review.data)
 
     else:
-        return HttpResponse(status=400)
+        return HttpResponse(status=302, )
 
-
-def get_review(request):
+@csrf_exempt
+def get_review_by_id(request):
     data = {}
-    if request.method == 'GET':
-        review_id = request.GET.get('token')
+    if request.method == 'POST':
+        review_id = request.POST.get('token')
         try:
             review = CurriculumReviewSession.objects.get(id=review_id)
             if review:
@@ -62,6 +66,24 @@ def get_review(request):
             return HttpResponse(status=404)
     return JsonResponse(data)
 
+@csrf_exempt
+def continue_review(request):
+    data = {}
+    if request.method == 'POST':
+        pass_code = request.POST.get('pass_code')
+        # Critical pause to prevent brute-forcing the shorter pass_code values
+        time.sleep(1)
+        try:
+            review = CurriculumReviewSession.objects.get(pass_code=pass_code)
+            if review:
+                data = review.data
+        except (
+            CurriculumReviewSession.DoesNotExist,
+            ValueError,
+            ValidationError
+        ):
+            return HttpResponseRedirect('../')
+    return HttpResponseRedirect('../tool/?token='+data.get('id'))
 
 @csrf_exempt
 def update_review(request):

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -5,7 +5,6 @@ from datetime import datetime
 from django.core.exceptions import ValidationError
 from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
 from django.utils import timezone
-from django.views.decorators.csrf import csrf_exempt
 
 from crtool.models import CurriculumReviewSession
 
@@ -17,7 +16,7 @@ def create_review(request):
         title = fd['tdp-crt_title'] if 'tdp-crt_title' in fd else ''
         pub_date = fd['tdp-crt_pubdate'] if 'tdp-crt_pubdate' in fd else ''
         grade_range = fd['tdp-crt_grade'] if 'tdp-crt_grade' in fd else ''
-        pass_code = CurriculumReviewSession.pass_code_generator()
+        pass_code = CurriculumReviewSession.pc_generator()
         review_id = CurriculumReviewSession.id_generator()
         last_updated = timezone.now()
 
@@ -45,8 +44,8 @@ def create_review(request):
         if review:
             return JsonResponse(review.data)
 
-    else:
-        return HttpResponse(status=302, )
+    return HttpResponse(status=404)
+
 
 def get_review_by_id(request):
     data = {}
@@ -62,7 +61,11 @@ def get_review_by_id(request):
             ValidationError
         ):
             return HttpResponse(status=404)
-    return JsonResponse(data)
+
+        return JsonResponse(data)
+
+    return HttpResponse(status=404)
+
 
 def continue_review(request):
     data = {}
@@ -79,8 +82,11 @@ def continue_review(request):
             ValueError,
             ValidationError
         ):
-            return HttpResponseRedirect('../')
-    return HttpResponseRedirect('../tool/#id='+data.get('id'))
+            return HttpResponse(status=404)
+
+        return HttpResponseRedirect('../tool/#id=' + data.get('id'))
+
+    return HttpResponse(status=404)
 
 def update_review(request):
     if request.method == 'POST':

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -83,7 +83,7 @@ def continue_review(request):
             ValidationError
         ):
             return HttpResponseRedirect('../')
-    return HttpResponseRedirect('../tool/?token='+data.get('id'))
+    return HttpResponseRedirect('../tool/#id='+data.get('id'))
 
 @csrf_exempt
 def update_review(request):

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 
 from django.core.exceptions import ValidationError
-from django.http import HttpResponse, JsonResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.utils import timezone
 
 from crtool.models import CurriculumReviewSession
@@ -47,7 +47,7 @@ def create_review(request):
     return HttpResponse(status=404)
 
 
-def get_review_by_id(request):
+def get_review(request):
     data = {}
     if request.method == 'POST':
         review_id = request.POST.get('token')
@@ -87,6 +87,7 @@ def continue_review(request):
         return HttpResponseRedirect('../tool/#id=' + data.get('id'))
 
     return HttpResponse(status=404)
+
 
 def update_review(request):
     if request.method == 'POST':

--- a/crtool/views.py
+++ b/crtool/views.py
@@ -10,7 +10,6 @@ from django.views.decorators.csrf import csrf_exempt
 from crtool.models import CurriculumReviewSession
 
 
-@csrf_exempt
 def create_review(request):
     if request.method == 'POST':
         fd = json.loads(request.body.decode("utf-8"))
@@ -49,7 +48,6 @@ def create_review(request):
     else:
         return HttpResponse(status=302, )
 
-@csrf_exempt
 def get_review_by_id(request):
     data = {}
     if request.method == 'POST':
@@ -66,7 +64,6 @@ def get_review_by_id(request):
             return HttpResponse(status=404)
     return JsonResponse(data)
 
-@csrf_exempt
 def continue_review(request):
     data = {}
     if request.method == 'POST':
@@ -85,7 +82,6 @@ def continue_review(request):
             return HttpResponseRedirect('../')
     return HttpResponseRedirect('../tool/#id='+data.get('id'))
 
-@csrf_exempt
 def update_review(request):
     if request.method == 'POST':
         data = json.loads(request.body.decode("utf-8"))

--- a/src/__tests__/crtoolLocalStorage/init_test.js
+++ b/src/__tests__/crtoolLocalStorage/init_test.js
@@ -7,10 +7,10 @@ const testToken = 'abcd';
 const consoleError = console.error;
 
 beforeEach(() => {
-  ls.locationSearch = '';
   global.localStorage.clear();
   ls.localStorage = global.localStorage;
-  ls.pushState = jest.fn();
+  ls.getLocationHash = jest.fn();
+  ls.setLocationHash = jest.fn();
   ls.setHref = jest.fn();
   ls.getHref = () => 'http://example.com/page';
   console.error = jest.fn();
@@ -33,7 +33,6 @@ it('init() gets token from LS, but LS nor server has it', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
   expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
   expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
@@ -47,7 +46,6 @@ it('init() gets token from LS, but LS is invalid', async () => {
   await ls.init();
 
   expect(console.error.mock.calls[0][0].message).toBe('invalid review');
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
   expect(ls.setHref.mock.calls[0][0]).toBe(C.START_PAGE_RELATIVE_URL);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toBe(null);
   expect(ls.localStorage.getItem('curriculumReviewId')).toBe(null);
@@ -74,7 +72,7 @@ it('init() finds DB review, but LS has older', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls[0][2]).toBe('http://example.com/page?token=' + testToken);
+  expect(ls.setLocationHash.mock.calls[0][0]).toBe('#id=' + testToken);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(dbReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
@@ -84,7 +82,7 @@ it('init() finds DB review, but LS has older', async () => {
 
 it('init() finds DB review and URL has token', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.localStorage.setItem('curriculumReviewId', testToken);
   ls.localStorage.setItem('crtool.' + testToken, JSON.stringify({
     id: testToken,
@@ -104,7 +102,7 @@ it('init() finds DB review and URL has token', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(dbReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"db"');
@@ -114,7 +112,7 @@ it('init() finds DB review and URL has token', async () => {
 
 it('init() finds DB review and LS has newer', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.localStorage.setItem('curriculumReviewId', testToken);
   const lsReview = {
     id: testToken,
@@ -135,7 +133,7 @@ it('init() finds DB review and LS has newer', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject(lsReview);
   expect(ls.localStorage.getItem('crtool.' + testToken)).toContain('"value":"local"');
@@ -145,7 +143,7 @@ it('init() finds DB review and LS has newer', async () => {
 
 it('init() finds fresh review, sets local time', async () => {
   const oldDate = new Date(new Date().getTime() - 1000e3);
-  ls.locationSearch = '?token=' + testToken;
+  ls.getLocationHash = () => '#id=' + testToken;
   ls.getISODate = () => oldDate.toISOString();
   const dbReview = {
     id: testToken,
@@ -158,7 +156,7 @@ it('init() finds fresh review, sets local time', async () => {
   await ls.init();
 
   expect(console.error.mock.calls.length).toBe(0);
-  expect(ls.pushState.mock.calls.length).toBe(0);
+  expect(ls.setLocationHash.mock.calls.length).toBe(0);
   expect(ls.setHref.mock.calls.length).toBe(0);
   expect(ls.review).toMatchObject({
     ...dbReview,

--- a/src/crtoolLocalStorage.js
+++ b/src/crtoolLocalStorage.js
@@ -11,8 +11,12 @@ export const CHECK_FREQUENCY = 10e3;
 const ls = {
     // Use DOM LocalStorage, but allow swapping
     localStorage: localStorage,
-    pushState: window.history.pushState,
-    locationSearch: window.location.search,
+    getLocationHash() {
+      return window.location.hash;
+    },
+    setLocationHash(hash) {
+        window.location.hash = hash;
+    },
     setHref(url) {
         window.location.href = url;
     },
@@ -37,8 +41,7 @@ const ls = {
     },
 
     updateUrl(review_id) {
-        const new_url = ls.updateUrlParameter(ls.getHref(), 'token', review_id);
-        ls.pushState({ path: new_url }, '', new_url);
+        ls.setLocationHash('#id=' + review_id);
     },
 
     scheduleSaveIfDirty(delay) {
@@ -52,7 +55,7 @@ const ls = {
     },
 
     async init() {
-        const token = ls.getUrlParameter('token');
+        const token = ls.getUrlToken();
         let review_id = token || ls.localStorage.getItem('curriculumReviewId') || '';
         if (!review_id) {
             return ls.redirectHome();
@@ -261,31 +264,12 @@ const ls = {
         ls.scheduleSaveIfDirty(CHECK_FREQUENCY);
     },
 
-    // IE compatible method for getting a querystring parameter from a URL
-    // Credit: https://stackoverflow.com/a/901144
-    getUrlParameter(name) {
-        name = name.replace(/\[/, '\\[').replace(/]/, '\\]');
-        const regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
-        const results = regex.exec(ls.locationSearch);
-        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    getUrlToken() {
+        return /id=(\w+)/.test(ls.getLocationHash()) ? RegExp.$1 : '';
     },
 
-    // Add / Update a key-value pair in the URL query parameters
-    // Credit: https://gist.github.com/niyazpk/f8ac616f181f6042d1e0
-    updateUrlParameter(uri, key, value) {
-        // remove the hash part before operating on the uri
-        const i = uri.indexOf('#');
-        const hash = i === -1 ? ''  : uri.substr(i);
-        uri = i === -1 ? uri : uri.substr(0, i);
-
-        const re = new RegExp("([?&])" + key + "=.*?(&|$)", "i");
-        const separator = uri.indexOf('?') !== -1 ? "&" : "?";
-        if (uri.match(re)) {
-            uri = uri.replace(re, '$1' + key + "=" + value + '$2');
-        } else {
-            uri = uri + separator + key + "=" + value;
-        }
-        return uri + hash;  // finally append the hash as well
+    setUrlToken(uri, token) {
+        return uri.replace(/#.*/, '') + '#id=' + token;
     },
 
     // TODO test that setting a novel item updates ls_modified_time on the

--- a/src/crtoolLocalStorage.js
+++ b/src/crtoolLocalStorage.js
@@ -151,6 +151,7 @@ const ls = {
         const xhttp = new XMLHttpRequest();
         xhttp.open("POST", "../get-review/", true);
         xhttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+        xhttp.setRequestHeader('X-CSRFToken', window.csrftoken);
         xhttp.timeout = 5e3;
 
         return new Promise((resolve, reject) => {
@@ -213,6 +214,7 @@ const ls = {
         xhttp.open("POST", "../update-review/", true);
         xhttp.timeout = 5e3;
         xhttp.setRequestHeader("Content-Type", "application/json;charset=UTF-8");
+        xhttp.setRequestHeader('X-CSRFToken', window.csrftoken);
 
         return new Promise((resolve, reject) => {
             xhttp.onreadystatechange = () => {

--- a/src/crtoolLocalStorage.js
+++ b/src/crtoolLocalStorage.js
@@ -146,7 +146,8 @@ const ls = {
         }
 
         const xhttp = new XMLHttpRequest();
-        xhttp.open("GET", "../get-review?token=" + review_id, true);
+        xhttp.open("POST", "../get-review/", true);
+        xhttp.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
         xhttp.timeout = 5e3;
 
         return new Promise((resolve, reject) => {
@@ -169,7 +170,7 @@ const ls = {
                 }
             };
 
-            xhttp.send();
+            xhttp.send("token=" + review_id);
         });
     },
 

--- a/src/js/business.logic/repository.js
+++ b/src/js/business.logic/repository.js
@@ -99,6 +99,10 @@ const Repository = {
         return crtoolLocalStorage.getItem("id");
     },
 
+    getCurriculumPassCode() {
+        return crtoolLocalStorage.getItem("pass_code");
+    },
+
     getPublicationDate() {
         return crtoolLocalStorage.getItem("publicationDate");
     },

--- a/src/js/components/CustomerReviewToolComponent.js
+++ b/src/js/components/CustomerReviewToolComponent.js
@@ -45,6 +45,7 @@ export default class CustomerReviewToolComponent extends React.Component {
 
             curriculumTitle: Repository.getCurriculumTitle(),
             curriculumId: Repository.getCurriculumId(),
+            curriculumPassCode: Repository.getCurriculumPassCode(),
             publicationDate: Repository.getPublicationDate(),
             gradeRange: Repository.getGradeRange(),
 
@@ -478,7 +479,7 @@ export default class CustomerReviewToolComponent extends React.Component {
                             <div className="h5 u-mb30">You’re reviewing</div>
                             <h1>{this.state.curriculumTitle}</h1>
                             <div className="h4 u-mb30">
-                                Access code: <strong>{this.state.curriculumId}</strong>
+                                Access code: <strong>{this.state.curriculumPassCode}</strong>
                                 <div className="u-inline-block u-ml15">
                                     <AccessCodeModal
                                         buttonText="Use this to save your work"
@@ -493,7 +494,7 @@ export default class CustomerReviewToolComponent extends React.Component {
                         <React.Fragment>
                             <div className="h4">You’re reviewing: <strong>{this.state.curriculumTitle}</strong></div>
                             <div className="h4">
-                                Access code: <strong>{this.state.curriculumId}</strong>
+                                Access code: <strong>{this.state.curriculumPassCode}</strong>
                                 <div className="u-inline-block u-ml15">
                                     <AccessCodeModal
                                         buttonText="Use this to save your work"

--- a/src/js/components/dialogs/SaveWorkModal.js
+++ b/src/js/components/dialogs/SaveWorkModal.js
@@ -113,7 +113,7 @@ export default class SaveWorkModal extends React.Component {
                                     </button>
                                     <h2 id="modal-save-work_title" className="h3">Saving your work</h2>
                                     <div id="modal-save-work_desc">
-                                        <p><strong>To return to a review you have already started, you need to save the unique access code for your review. The access code can be found at the top left of your screen or in the review's URL.</strong></p>
+                                        <p><strong>To return to a review you have already started, you need to save the unique access code for your review. The access code can be found at the top left of your screen.</strong></p>
                                         <p>Your work will be saved automatically at regular intervals. However, you can also save your work at any time by clicking the “Save my work” button at the bottom of each dimension page.</p>
                                         <p>To save a permanent copy of your work, please print the summary or save it as a PDF for every dimension as you complete it. You can also print or save a summary of the entire review. Learn how to <a href="https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/" target="_blank" rel="noopener noreferrer" onClick={(e) => {this.props.sendAnalyticsForLinkClick("save the summary as a PDF", "https://www.consumerfinance.gov/consumer-tools/save-as-pdf-instructions/");}}>save the summary as a PDF</a>.</p>
                                         <p>You can have multiple reviews in progress at a time. Each will have a unique access code.</p>


### PR DESCRIPTION
Access codes are now 8 digits, but treated more like passwords: Trying an access code takes at least a second, which presents a big hurdle to any attempt to brute force access codes. While the access code is stored in plain text, it's random so an attacker with a copy of the DB wouldn't have anything of value anyway.

Session IDs are left as 22-digits (>128-bit entropy) and all communication of these is moved to POST operations for more security.

Also session IDs are no longer sent in querystrings so they cannot be logged.
